### PR TITLE
fix SkkEngine::loadDictionary() envvar behavior

### DIFF
--- a/gui/adddictdialog.cpp
+++ b/gui/adddictdialog.cpp
@@ -15,7 +15,7 @@
 #include <QFileDialog>
 #include <QLineEdit>
 #include <QPushButton>
-#include <fcitx-utils/standardpath.h>
+#include <fcitx-utils/standardpaths.h>
 #include <fcitxqti18nhelper.h>
 
 #define FCITX_CONFIG_DIR "$FCITX_CONFIG_DIR"
@@ -95,17 +95,17 @@ void AddDictDialog::browseClicked() {
     path = QFileDialog::getOpenFileName(this, _("Select Dictionary File"),
                                         info.path());
   } else {
-    auto fcitxBasePath = stringutils::joinPath(
-        StandardPath::global().userDirectory(StandardPath::Type::PkgData),
-        "cskk");
+    auto fcitxBasePath =
+        StandardPaths::global().userDirectory(StandardPathsType::PkgData) /
+        "cskk";
     fs::makePath(fcitxBasePath);
     QString fcitxConfigBasePath =
         QDir::cleanPath(QString::fromStdString(fcitxBasePath));
 
     if (path.isEmpty()) {
-      auto baseDataPath = stringutils::joinPath(
-          StandardPath::global().userDirectory(StandardPath::Type::Data),
-          "fcitx5-cskk");
+      auto baseDataPath =
+          StandardPaths::global().userDirectory(StandardPathsType::Data) /
+          "fcitx5-cskk";
       fs::makePath(baseDataPath);
       QString basePath = QDir::cleanPath(QString::fromStdString(baseDataPath));
       path = basePath;

--- a/gui/dictmodel.cpp
+++ b/gui/dictmodel.cpp
@@ -12,7 +12,7 @@
 #include <QStringList>
 #include <QTemporaryFile>
 #include <QtGlobal>
-#include <fcitx-utils/standardpath.h>
+#include <fcitx-utils/standardpaths.h>
 #include <fcntl.h>
 #include <iostream>
 
@@ -23,16 +23,16 @@ const std::string config_path = "cskk/dictionary_list";
 SkkDictModel::SkkDictModel(QObject *parent) : QAbstractListModel(parent) {}
 
 void SkkDictModel::defaults() {
-  auto path = StandardPath::fcitxPath("pkgdatadir", config_path.c_str());
-  QFile f(path.data());
+  auto path = StandardPaths::fcitxPath("pkgdatadir", config_path.c_str());
+  QFile f(path);
   if (f.open(QIODevice::ReadOnly)) {
     load(f);
   }
 }
 
 void SkkDictModel::load() {
-  auto file = StandardPath::global().open(StandardPath::Type::PkgData,
-                                          config_path, O_RDONLY);
+  auto file =
+      StandardPaths::global().open(StandardPathsType::PkgData, config_path);
   if (file.fd() < 0) {
     return;
   }
@@ -61,8 +61,8 @@ void SkkDictModel::load(QFile &file) {
 }
 
 bool SkkDictModel::save() {
-  return StandardPath::global().safeSave(
-      StandardPath::Type::PkgData, config_path, [this](int fd) {
+  return StandardPaths::global().safeSave(
+      StandardPathsType::PkgData, config_path, [this](int fd) {
         QFile tempFile;
         if (!tempFile.open(fd, QIODevice::WriteOnly)) {
           return false;

--- a/gui/dictwidget.cpp
+++ b/gui/dictwidget.cpp
@@ -10,7 +10,7 @@
 #include "dictmodel.h"
 #include <QItemSelectionModel>
 #include <fcitx-utils/fs.h>
-#include <fcitx-utils/standardpath.h>
+#include <fcitx-utils/standardpaths.h>
 #include <fcitx-utils/stringutils.h>
 #include <fcitxqti18nhelper.h>
 
@@ -21,9 +21,9 @@ SkkDictWidget::SkkDictWidget(QWidget *parent)
       m_ui(std::make_unique<Ui::SkkDictWidget>()) {
   m_ui->setupUi(this);
   m_dictModel = new SkkDictModel(this);
-  auto fcitxBasePath = stringutils::joinPath(
-      StandardPath::global().userDirectory(StandardPath::Type::PkgData),
-      "cskk");
+  auto fcitxBasePath =
+      StandardPaths::global().userDirectory(StandardPathsType::PkgData) /
+      "cskk";
   fs::makePath(fcitxBasePath);
 
   m_dictModel->load();

--- a/src/cskk.cpp
+++ b/src/cskk.cpp
@@ -26,7 +26,7 @@
 #include <fcitx-utils/key.h>
 #include <fcitx-utils/keysym.h>
 #include <fcitx-utils/log.h>
-#include <fcitx-utils/standardpath.h>
+#include <fcitx-utils/standardpaths.h>
 #include <fcitx-utils/stringutils.h>
 #include <fcitx-utils/textformatflags.h>
 #include <fcitx/addoninstance.h>
@@ -131,8 +131,8 @@ typedef enum _FcitxSkkDictType { FSDT_Invalid, FSDT_File } FcitxSkkDictType;
 void FcitxCskkEngine::loadDictionary() {
   freeDictionaries();
 
-  auto dict_config_file = StandardPath::global().open(
-      StandardPath::Type::PkgData, "cskk/dictionary_list", O_RDONLY);
+  auto dict_config_file = StandardPaths::global().open(
+      StandardPathsType::PkgData, "cskk/dictionary_list");
 
   if (!dict_config_file.isValid()) {
     return;
@@ -217,9 +217,9 @@ void FcitxCskkEngine::loadDictionary() {
       constexpr auto var_len = sizeof(configDir) - 1;
       std::string realpath = path;
       if (stringutils::startsWith(path, configDir)) {
-        realpath = stringutils::joinPath(
-            StandardPath::global().userDirectory(StandardPath::Type::PkgData),
-            path.substr(var_len));
+        realpath =
+            StandardPaths::global().userDirectory(StandardPathsType::PkgData) /
+            path.substr(var_len);
       }
       auto *userdict =
           skk_user_dict_new(realpath.c_str(), encoding.c_str(), complete);
@@ -404,7 +404,8 @@ void FcitxCskkContext::updateUI() {
 
   // Preedit
   uint32_t stateStackLen;
-  auto *preeditDetail = skk_context_get_preedit_detail(context_, &stateStackLen);
+  auto *preeditDetail =
+      skk_context_get_preedit_detail(context_, &stateStackLen);
   auto [mainPreedit, supplementPreedit] =
       FcitxCskkContext::formatPreedit(preeditDetail, stateStackLen);
   skk_free_preedit_detail(preeditDetail, stateStackLen);
@@ -427,8 +428,7 @@ void FcitxCskkContext::updateUI() {
           std::make_unique<FcitxCskkCandidateList>(engine_, ic_));
     } else {
       // Sync UI with actual data
-      currentCandidateList->setCursorPosition(
-          currentCursorPosition);
+      currentCandidateList->setCursorPosition(currentCursorPosition);
     }
 
   } else {

--- a/src/cskk.cpp
+++ b/src/cskk.cpp
@@ -201,26 +201,29 @@ void FcitxCskkEngine::loadDictionary() {
       CSKK_WARN() << "Invalid dictionary path or mode. Ignored";
       continue;
     }
+
+    constexpr char configDir[] = "$FCITX_CONFIG_DIR/";
+    constexpr auto var_len = sizeof(configDir) - 1;
+    std::string realpath = path;
+    if (stringutils::startsWith(path, configDir)) {
+      realpath =
+          StandardPaths::global().userDirectory(StandardPathsType::PkgData) /
+          path.substr(var_len);
+    }
+
     if (mode == 1) {
       // readonly mode
-      auto *dict = skk_file_dict_new(path.c_str(), encoding.c_str(), complete);
+      auto *dict =
+          skk_file_dict_new(realpath.c_str(), encoding.c_str(), complete);
       if (dict) {
-        CSKK_DEBUG() << "Adding file dict: " << path
+        CSKK_DEBUG() << "Adding file dict: " << realpath
                      << " complete:" << complete;
         dictionaries_.emplace_back(dict);
       } else {
-        CSKK_WARN() << "Static dictionary load error. Ignored: " << path;
+        CSKK_WARN() << "Static dictionary load error. Ignored: " << realpath;
       }
     } else {
       // read/write mode
-      constexpr char configDir[] = "$FCITX_CONFIG_DIR/";
-      constexpr auto var_len = sizeof(configDir) - 1;
-      std::string realpath = path;
-      if (stringutils::startsWith(path, configDir)) {
-        realpath =
-            StandardPaths::global().userDirectory(StandardPathsType::PkgData) /
-            path.substr(var_len);
-      }
       auto *userdict =
           skk_user_dict_new(realpath.c_str(), encoding.c_str(), complete);
       if (userdict) {


### PR DESCRIPTION
The first commit updates the use of the old API.
I based this on fcitx/fcitx5-skk@0ebea29.

For the main body modifications, please refer to fcitx/fcitx5-skk#20.