### PR TITLE
simplify path resolve in loadDictionary

### DIFF
--- a/src/cskk.cpp
+++ b/src/cskk.cpp
@@ -202,35 +202,31 @@ void FcitxCskkEngine::loadDictionary() {
       continue;
     }
 
-    constexpr char configDir[] = "$FCITX_CONFIG_DIR/";
-    constexpr auto var_len = sizeof(configDir) - 1;
-    std::string realpath = path;
-    if (stringutils::startsWith(path, configDir)) {
-      realpath =
-          StandardPaths::global().userDirectory(StandardPathsType::PkgData) /
-          path.substr(var_len);
+    std::string_view partialpath = path;
+    if (stringutils::consumePrefix(partialpath, "$FCITX_CONFIG_DIR/")) {
+      path = StandardPaths::global().userDirectory(StandardPathsType::PkgData) /
+             partialpath;
     }
 
     if (mode == 1) {
       // readonly mode
-      auto *dict =
-          skk_file_dict_new(realpath.c_str(), encoding.c_str(), complete);
+      auto *dict = skk_file_dict_new(path.c_str(), encoding.c_str(), complete);
       if (dict) {
-        CSKK_DEBUG() << "Adding file dict: " << realpath
+        CSKK_DEBUG() << "Adding file dict: " << path
                      << " complete:" << complete;
         dictionaries_.emplace_back(dict);
       } else {
-        CSKK_WARN() << "Static dictionary load error. Ignored: " << realpath;
+        CSKK_WARN() << "Static dictionary load error. Ignored: " << path;
       }
     } else {
       // read/write mode
       auto *userdict =
-          skk_user_dict_new(realpath.c_str(), encoding.c_str(), complete);
+          skk_user_dict_new(path.c_str(), encoding.c_str(), complete);
       if (userdict) {
-        CSKK_DEBUG() << "Adding user dict: " << realpath;
+        CSKK_DEBUG() << "Adding user dict: " << path;
         dictionaries_.emplace_back(userdict);
       } else {
-        CSKK_WARN() << "User dictionary load error. Ignored: " << realpath;
+        CSKK_WARN() << "User dictionary load error. Ignored: " << path;
       }
     }
   }


### PR DESCRIPTION
stringutils::startsWith is deprecated, so replace it with the same logic with [fcitx5-skk](https://github.com/fcitx/fcitx5-skk/blob/d4c2d89fb066f93e6d95a37969889e36c03f5129/src/skk.cpp#L538)